### PR TITLE
Fix track not advancing in same state on Linux

### DIFF
--- a/DynamicMusicPlayer/DynamicMusicPlayer.lua
+++ b/DynamicMusicPlayer/DynamicMusicPlayer.lua
@@ -2,6 +2,63 @@
 CSPBuild = ac.getPatchVersionCode()
 math.randomseed(os.preciseClock())
 
+local isDebug = false
+local _debugLines = {}
+local _debugLogPath = __dirname .. '/debug.log'
+local function dbg(msg)
+    if not isDebug then return end
+    table.insert(_debugLines, string.format("[%.2f] %s", os.preciseClock(), msg))
+end
+local function flushDebugLog()
+    if not isDebug then return end
+    io.save(_debugLogPath, table.concat(_debugLines, '\n') .. '\n')
+end
+
+-- Use ac.AudioEvent.fromFile (FMOD-based, works on Linux/Proton) instead of
+-- ui.MediaPlayer (MMF-based, broken on Linux). Wrapper keeps the same interface.
+local function safeMediaPlayer(path)
+    local ok, ev = pcall(ac.AudioEvent.fromFile, {filename = path, use3D = false, loop = false}, false)
+    if not ok or not ev or not ev:isValid() then
+        if isDebug then dbg("safeMediaPlayer FAILED for: " .. tostring(path)) end
+        return nil
+    end
+    if isDebug then dbg("safeMediaPlayer OK: " .. tostring(path)) end
+    local knownDuration = 0
+    local lastPosition = 0
+    local finished = false
+    return {
+        _ev = ev,
+        play          = function(self) self._ev:start() end,
+        setVolume     = function(self, v) self._ev.volume = math.max(0, v) end,
+        volume        = function(self) return self._ev.volume end,
+        duration      = function(self)
+            local d = self._ev:getDuration()
+            if d > 0 then knownDuration = d end
+            return knownDuration
+        end,
+        currentTime   = function(self)
+            local pos = self._ev:getTimelinePosition()
+            if finished then return knownDuration end
+            -- FMOD resets position to 0 when a non-looping event finishes.
+            -- Detect this by checking if position jumped back to 0 after being well into the track.
+            if pos == 0 and lastPosition > 1.0 then
+                finished = true
+                return knownDuration
+            end
+            lastPosition = pos
+            return pos
+        end,
+        isValid       = function(self) return self._ev:isValid() end,
+        setCurrentTime = function(self, t)
+            if t >= self._ev:getDuration() then
+                self._ev:stop()
+            else
+                self._ev:seek(t)
+            end
+        end,
+    }
+end
+
 CoverArtExportCanvas = ui.ExtraCanvas(vec2(256, 256), 1, render.AntialiasingMode.ExtraSharpCMAA)
 function RenderCoverArtExportCanvas()
     CoverArtExportCanvas:clear()
@@ -455,6 +512,15 @@ function updateRaceStatusData()
         TargetVolume = -10
     else
         TargetVolume = MaxVolume
+    end
+    if isDebug and CurrentTrack and UpdateCounter % 300 == 0 then
+        local ct = CurrentTrack:currentTime()
+        local dur = CurrentTrack:duration()
+        local valid = CurrentTrack:isValid()
+        local fadeCondition = ct > dur - 2
+        local loadCondition = ct >= dur - 1
+        dbg(string.format("TRACK STATE | isValid=%s | currentTime=%.3f | duration=%.3f | fadeCondition=%s | loadCondition=%s | TargetVolume=%.3f",
+            tostring(valid), ct, dur, tostring(fadeCondition), tostring(loadCondition), TargetVolume))
     end
 
     if MusicType and ( -- boost fade-in music 
@@ -1131,6 +1197,14 @@ function script.update(dt)
         updateRaceStatusData()
     end
 
+    if isDebug and UpdateCounter%60 == 1 and CurrentTrack then
+        local ct = CurrentTrack:currentTime()
+        local dur = CurrentTrack:duration()
+        local valid = CurrentTrack:isValid()
+        dbg(string.format("LOAD CHECK | isValid=%s | currentTime=%.3f | duration=%.3f | condition(ct>=dur-1)=%s",
+            tostring(valid), ct, dur, tostring(ct >= dur - 1)))
+    end
+
     if (StartMusic == true and Sim.timeToSessionStart < 0) or
     UpdateCounter%60 == 1 and
     EnableMusic and
@@ -1145,7 +1219,7 @@ function script.update(dt)
             CurrentVolume = 0
         end
         if #MusicQueue == 0 or (PlayerFinished and (not PlayedFinishTrack) and FinishMusic[1]) then
-            CurrentTrack = ui.MediaPlayer(getNewTrack())
+            CurrentTrack = safeMediaPlayer(getNewTrack())
             DontSkipCurrentTrack = false
         else
             PlaySelectedTrack(MusicQueue[1])
@@ -1195,7 +1269,7 @@ function script.update(dt)
                 if EnableMusic and SkipAttempts > 20 and (Session.type ~= 3 or (Session.type == 3 and (Sim.timeToSessionStart < 0 or Sim.timeToSessionStart >= 60000))) and HitValue == 0 then
                     updateRaceStatusData()
                     if #MusicQueue == 0 or (PlayerFinished and (not PlayedFinishTrack) and FinishMusic[1])  then
-                        CurrentTrack = ui.MediaPlayer(getNewTrack())
+                        CurrentTrack = safeMediaPlayer(getNewTrack())
                         DontSkipCurrentTrack = false
                     else
                         PlaySelectedTrack(MusicQueue[1])
@@ -1240,6 +1314,10 @@ function script.update(dt)
 
     --runGC()
     --printGC()
+
+    if isDebug and UpdateCounter%60 == 0 then
+        flushDebugLog()
+    end
 end
 
 function TabsFunction()
@@ -1255,7 +1333,7 @@ end
 function PlaySelectedTrack(selectedTrack)
     CurrentTrack:setVolume(0)
     CurrentTrack:setCurrentTime(CurrentTrack:duration())
-    CurrentTrack = ui.MediaPlayer(selectedTrack[2])
+    CurrentTrack = safeMediaPlayer(selectedTrack[2])
     CurrentVolume = TargetVolume*TargetVolumeMultiplier
     CurrentTrack:setVolume(CurrentVolume)
     CurrentTrack:play()


### PR DESCRIPTION
Replace ui.MediaPlayer with ac.AudioEvent.fromFile via a wrapper, fixing audio playback on Linux/Proton where Windows Media Foundation is unavailable.

Also includes a toggleable debug logger (local isDebug = false at the top).